### PR TITLE
Add improved type checking

### DIFF
--- a/examples/basic/src/base-example.tsx
+++ b/examples/basic/src/base-example.tsx
@@ -27,7 +27,7 @@ const SliderInputContainer = ({
     sliderValue,
   }, {
     setSliderValue,
-  }] = useCoordination(viewUid, ['sliderValue']);
+  }] = useCoordination<CT>(viewUid, ['sliderValue']);
   return (
     <SliderInput
       sliderValue={sliderValue}
@@ -40,6 +40,7 @@ const SliderInputContainer = ({
 const pluginCoordinationTypes = {
   sliderValue: z.number(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,

--- a/examples/basic/src/meta-example.tsx
+++ b/examples/basic/src/meta-example.tsx
@@ -26,7 +26,7 @@ const SliderInputContainer = ({
     sliderValue,
   }, {
     setSliderValue,
-  }] = useCoordination(viewUid, ['sliderValue']);
+  }] = useCoordination<CT>(viewUid, ['sliderValue']);
   return (
     <SliderInput
       sliderValue={sliderValue}
@@ -38,6 +38,7 @@ const SliderInputContainer = ({
 const pluginCoordinationTypes = {
   sliderValue: z.number(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialMetaSpec = {
   key: 1,

--- a/examples/basic/src/meta-multi-level-example.tsx
+++ b/examples/basic/src/meta-multi-level-example.tsx
@@ -33,7 +33,7 @@ const SliderInputContainer = ({
     channelValue,
   }, {
     setChannelValue,
-  }] = useCoordination(viewUid, ['channelValue']);
+  }] = useCoordination<CT>(viewUid, ['channelValue']);
   return (
     <SliderInput
       sliderValue={channelValue}
@@ -92,8 +92,8 @@ const ColorfulSliderInputContainer = ({
 }: any) => {
 
   // Support meta-coordination.
-  const channelScopes = useCoordinationScopes(viewUid, "channel");
-  const channelCoordination = useCoordinationL1(viewUid, "channel", [
+  const channelScopes = useCoordinationScopes<CT>(viewUid, "channel");
+  const channelCoordination = useCoordinationL1<CT>(viewUid, "channel", [
     "channelValue"
   ]);
 
@@ -110,6 +110,7 @@ const pluginCoordinationTypes = {
   channel: z.literal('__dummy__'),
   channelValue: z.number(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = {
   key: 1,

--- a/examples/basic/src/multi-coordination-type-example.tsx
+++ b/examples/basic/src/multi-coordination-type-example.tsx
@@ -59,7 +59,7 @@ const ColorfulSliderInputContainer = ({
   }, {
     setValue,
     setColor,
-  }] = _useCoordination(coordinationScopes, ['value', 'color']);
+  }] = _useCoordination<CT>(coordinationScopes, ['value', 'color']);
   return (
     <ColorfulSliderInput
       value={value}
@@ -74,6 +74,7 @@ const pluginCoordinationTypes = {
   value: z.number(),
   color: z.array(z.number()).length(3),
 };
+type CT = typeof pluginCoordinationTypes;
 
 
 const initialSpec = {

--- a/examples/basic/src/multi-level-example.tsx
+++ b/examples/basic/src/multi-level-example.tsx
@@ -36,7 +36,7 @@ const SliderInputContainer = ({
     channelValue,
   }, {
     setChannelValue,
-  }] = useCoordination(viewUid, ['channelValue']);
+  }] = useCoordination<CT>(viewUid, ['channelValue']);
   return (
     <SliderInput
       sliderValue={channelValue}
@@ -93,8 +93,8 @@ const ColorfulSliderInput = ({
 const ColorfulSliderInputContainer = ({
   viewUid,
 }: any) => {
-  const channelScopes = useCoordinationScopes(viewUid, "channel");
-  const channelCoordination = useCoordinationL1(viewUid, "channel", ["channelValue"]);
+  const channelScopes = useCoordinationScopes<CT>(viewUid, "channel");
+  const channelCoordination = useCoordinationL1<CT>(viewUid, "channel", ["channelValue"]);
   return (
     <ColorfulSliderInput
       channelScopes={channelScopes}
@@ -107,6 +107,7 @@ const pluginCoordinationTypes = {
   channel: z.literal('__dummy__'),
   channelValue: z.number(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = {
   key: 1,

--- a/examples/basic/src/multi-view-type-example.tsx
+++ b/examples/basic/src/multi-view-type-example.tsx
@@ -26,7 +26,7 @@ const SliderInputContainer = ({
     value,
   }, {
     setValue,
-  }] = useCoordination(viewUid, ['value']);
+  }] = useCoordination<CT>(viewUid, ['value']);
   return (
     <SliderInput
       value={value}
@@ -54,7 +54,7 @@ const NumericInputContainer = ({
     value,
   }, {
     setValue,
-  }] = useCoordination(viewUid, ['value']);
+  }] = useCoordination<CT>(viewUid, ['value']);
   return (
     <NumericInput
     value={value}
@@ -67,7 +67,8 @@ const NumericInputContainer = ({
 
 const pluginCoordinationTypes = {
   value: z.number(),
-}
+};
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec2 = {
   key: 1,

--- a/examples/plots/src/d3.tsx
+++ b/examples/plots/src/d3.tsx
@@ -7,6 +7,7 @@ import {
 } from 'd3-array';
 import { select } from 'd3-selection';
 import { useCoordination } from '@use-coordination/all';
+import type { CT } from './plots-example.js';
 
 const scaleBand = vega_scale('band');
 
@@ -144,7 +145,7 @@ export function D3BarPlotView(props: any) {
   const [
     { barSelection },
     { setBarSelection },
-  ] = useCoordination(viewUid, ["barSelection"]);
+  ] = useCoordination<CT>(viewUid, ["barSelection"]);
 
   return (
     <>

--- a/examples/plots/src/mnist-example.tsx
+++ b/examples/plots/src/mnist-example.tsx
@@ -23,6 +23,7 @@ const pluginCoordinationTypes = {
   zoomOffset: z.number().nullable(),
   target: z.array(z.number()).length(2).nullable(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,
@@ -104,10 +105,10 @@ function MnistScatterplot(props: any) {
   }, {
     setZoomLevel,
     setTarget,
-  }] = useCoordination(viewUid, ["zoomLevel", "zoomOffset", "target"]);
+  }] = useCoordination<CT>(viewUid, ["zoomLevel", "zoomOffset", "target"]);
 
   const onViewStateChange = useCallback(({viewState}: any) => {
-    setZoomLevel(viewState.zoom - zoomOffset);
+    setZoomLevel(viewState.zoom - (zoomOffset ?? 0));
     setTarget([viewState.target[0], viewState.target[1]]);
   }, []);
   const views = useMemo(() => {
@@ -165,8 +166,8 @@ function MnistScatterplot(props: any) {
         controller={true}
         layers={layers}
         viewState={{
-          target: [target[0], target[1], 0],
-          zoom: zoomLevel + zoomOffset,
+          target: target ? [target[0], target[1], 0] : [0, 0, 0],
+          zoom: (zoomLevel ?? 0) + (zoomOffset ?? 0),
         }}
         onViewStateChange={onViewStateChange}
         views={views}

--- a/examples/plots/src/multilevel-colors.tsx
+++ b/examples/plots/src/multilevel-colors.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useCoordinationScopes, useCoordinationL1, useCoordinationObject } from '@use-coordination/all';
+import type { MultiLevelCT } from './multilevel-example.js';
 
 function ColorPicker(props: any) {
   const {
@@ -21,9 +22,9 @@ export function MultilevelColors(props: any) {
     viewUid,
   } = props;
 
-  const selectionScopes = useCoordinationScopes(viewUid, "barSelection");
-  const selectionValues = useCoordinationObject(viewUid, "barSelection");
-  const selectionCoordination = useCoordinationL1(viewUid, "barSelection", ["barColor"]);
+  const selectionScopes = useCoordinationScopes<MultiLevelCT>(viewUid, "barSelection");
+  const selectionValues = useCoordinationObject<MultiLevelCT>(viewUid, "barSelection");
+  const selectionCoordination = useCoordinationL1<MultiLevelCT>(viewUid, "barSelection", ["barColor"]);
 
   return (
     <div>

--- a/examples/plots/src/multilevel-d3.tsx
+++ b/examples/plots/src/multilevel-d3.tsx
@@ -5,7 +5,7 @@ import { axisBottom, axisLeft } from 'd3-axis';
 import { max } from 'd3-array';
 import { select } from 'd3-selection';
 import { useCoordinationScopes, useCoordinationL1, useCoordinationObject } from '@use-coordination/all';
-import { useSelectBar, useUnselectBar } from './multilevel-example.js';
+import { useSelectBar, useUnselectBar, type MultiLevelCT } from './multilevel-example.js';
 
 const scaleBand = vega_scale('band');
 
@@ -143,9 +143,9 @@ export function MultiLevelD3BarPlotView(props: any) {
   const selectBar = useSelectBar();
   const unselectBar = useUnselectBar();
 
-  const selectionScopes = useCoordinationScopes(viewUid, "barSelection");
-  const selectionCoordination = useCoordinationL1(viewUid, "barSelection", ["barColor", "barValue"]);
-  const selectionValues = useCoordinationObject(viewUid, "barSelection");
+  const selectionScopes = useCoordinationScopes<MultiLevelCT>(viewUid, "barSelection");
+  const selectionCoordination = useCoordinationL1<MultiLevelCT>(viewUid, "barSelection", ["barColor"]);
+  const selectionValues = useCoordinationObject<MultiLevelCT>(viewUid, "barSelection");
 
   const barSelection = selectionScopes.map(scope => selectionValues[scope]);
   const barColors = Object.fromEntries(selectionScopes.map(scope => ([

--- a/examples/plots/src/multilevel-example.tsx
+++ b/examples/plots/src/multilevel-example.tsx
@@ -18,10 +18,11 @@ import { MultilevelColors } from './multilevel-colors.js';
 const getNextSelectionScope = createPrefixedGetNextScopeNumeric("S");
 const getNextColorScope = createPrefixedGetNextScopeNumeric("C");
 
-const pluginCoordinationTypes = {
+export const pluginCoordinationTypes = {
   barSelection: z.string().nullable(),
   barColor: z.string().nullable(),
 };
+export type MultiLevelCT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,

--- a/examples/plots/src/multilevel-vega-lite.tsx
+++ b/examples/plots/src/multilevel-vega-lite.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, Suspense, useCallback } from 'react';
 import { clamp } from 'lodash-es';
 import { useCoordinationScopes, useCoordinationL1, useCoordinationObject } from '@use-coordination/all';
 import { Vega, VisualizationSpec } from 'react-vega';
-import { useSelectBar, useUnselectBar } from './multilevel-example.js';
+import { useSelectBar, useUnselectBar, type MultiLevelCT } from './multilevel-example.js';
 
 const DATASET_NAME = 'table';
 const partialSpec = {
@@ -143,9 +143,9 @@ export function MultiLevelVegaLitePlotView(props: any) {
   const selectBar = useSelectBar();
   const unselectBar = useUnselectBar();
 
-  const selectionScopes = useCoordinationScopes(viewUid, "barSelection");
-  const selectionCoordination = useCoordinationL1(viewUid, "barSelection", ["barColor", "barValue"]);
-  const selectionValues = useCoordinationObject(viewUid, "barSelection");
+  const selectionScopes = useCoordinationScopes<MultiLevelCT>(viewUid, "barSelection");
+  const selectionCoordination = useCoordinationL1<MultiLevelCT>(viewUid, "barSelection", ["barColor"]);
+  const selectionValues = useCoordinationObject<MultiLevelCT>(viewUid, "barSelection");
 
   const barSelection = selectionScopes.map(scope => selectionValues[scope]);
   const barColors = Object.fromEntries(selectionScopes.map(scope => ([

--- a/examples/plots/src/plotly.tsx
+++ b/examples/plots/src/plotly.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Plot from 'react-plotly.js';
 import { useCoordination } from '@use-coordination/all';
+import type { CT } from './plots-example.js';
 
 function PlotlyBarPlot(props: any) {
   const {
@@ -65,7 +66,7 @@ export function PlotlyBarPlotView(props: any) {
   const [
     { barSelection },
     { setBarSelection },
-  ] = useCoordination(viewUid, ["barSelection"]);
+  ] = useCoordination<CT>(viewUid, ["barSelection"]);
 
   return (
     <>

--- a/examples/plots/src/plots-example.tsx
+++ b/examples/plots/src/plots-example.tsx
@@ -14,9 +14,10 @@ import { VisxPlotView } from './visx.js';
 import { PlotlyBarPlotView } from './plotly.js';
 
 
-const pluginCoordinationTypes = {
+export const pluginCoordinationTypes = {
   barSelection: z.array(z.string()).nullable(),
 };
+export type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,

--- a/examples/plots/src/splom-example.tsx
+++ b/examples/plots/src/splom-example.tsx
@@ -338,7 +338,7 @@ function D3Scatterplot(props: any) {
     "selectionDimY",
     "selectionRangeX",
     "selectionRangeY",
-  ]);
+  ] as const);
 
   const setBrushSelection = useCallback((rangeX: null|[number, number], rangeY: null|[number, number]) => {
     setSelectionRangeX(rangeX);

--- a/examples/plots/src/splom-example.tsx
+++ b/examples/plots/src/splom-example.tsx
@@ -48,6 +48,7 @@ const pluginCoordinationTypes = {
   selectionRangeX: z.array(z.number()).length(2).nullable(),
   selectionRangeY: z.array(z.number()).length(2).nullable(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,
@@ -285,7 +286,7 @@ function useScale(dimName: string, range: [number, number]) {
   });
 }
 
-function useSelectedPlotData(selectionDimX: string, selectionDimY: string, selectionRangeX: [number, number], selectionRangeY: [number, number]) {
+function useSelectedPlotData(selectionDimX: string | null, selectionDimY: string | null, selectionRangeX: number[] | null, selectionRangeY: number[] | null) {
   const { data, isLoading, isSuccess } = usePenguinsData();
   return useQuery({
     enabled: !isLoading && isSuccess,
@@ -330,7 +331,7 @@ function D3Scatterplot(props: any) {
     setSelectionDimY,
     setSelectionRangeX,
     setSelectionRangeY,
-  }] = useCoordination(viewUid, [
+  }] = useCoordination<CT>(viewUid, [
     "dimX",
     "dimY",
     "selectionDimX",
@@ -514,7 +515,7 @@ function PlotlyScatterplot(props: any) {
     setSelectionDimY,
     setSelectionRangeX,
     setSelectionRangeY,
-  }] = useCoordination(viewUid, [
+  }] = useCoordination<CT>(viewUid, [
     "dimX",
     "dimY",
     "selectionDimX",

--- a/examples/plots/src/vega-lite.tsx
+++ b/examples/plots/src/vega-lite.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, Suspense, useCallback } from 'react';
 import { clamp } from 'lodash-es';
 import { useCoordination } from '@use-coordination/all';
+import type { CT } from './plots-example.js';
 import { Vega, VisualizationSpec } from 'react-vega';
 
 const DATASET_NAME = 'table';
@@ -146,7 +147,7 @@ export function VegaLitePlotView(props: any) {
   const [
     { barSelection },
     { setBarSelection },
-  ] = useCoordination(viewUid, ["barSelection"]);
+  ] = useCoordination<CT>(viewUid, ["barSelection"]);
 
   const data = useMemo(() => {
     return dataProp.map((d: any) => ({

--- a/examples/plots/src/visx.tsx
+++ b/examples/plots/src/visx.tsx
@@ -5,6 +5,7 @@ import { LetterFrequency } from '@visx/mock-data/lib/mocks/letterFrequency';
 import { scaleBand, scaleLinear } from '@visx/scale';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { useCoordination } from '@use-coordination/all';
+import type { CT } from './plots-example.js';
 
 const getLetter = (d: LetterFrequency) => d.letter;
 const getLetterFrequency = (d: LetterFrequency) => Number(d.frequency);
@@ -103,7 +104,7 @@ export function VisxPlotView(props: any) {
   const [
     { barSelection },
     { setBarSelection },
-  ] = useCoordination(viewUid, ["barSelection"]);
+  ] = useCoordination<CT>(viewUid, ["barSelection"]);
 
   return (
     <>

--- a/examples/plots/src/weather-bars.tsx
+++ b/examples/plots/src/weather-bars.tsx
@@ -9,6 +9,7 @@ import {
 } from 'd3-array';
 import { select } from 'd3-selection';
 import { useCoordination } from '@use-coordination/all';
+import type { WeatherCT } from './weather.js';
 
 const scaleBand = vega_scale('band');
 
@@ -188,7 +189,7 @@ export function WeatherBarsView(props: any) {
   const [
     { maxTempSelection, precipitationSelection },
     { setMaxTempSelection, setPrecipitationSelection },
-  ] = useCoordination(viewUid, ["maxTempSelection", "precipitationSelection"]);
+  ] = useCoordination<WeatherCT>(viewUid, ["maxTempSelection", "precipitationSelection"]);
 
   return (
     <WeatherBars

--- a/examples/plots/src/weather-temp-precip.tsx
+++ b/examples/plots/src/weather-temp-precip.tsx
@@ -9,6 +9,7 @@ import {
 import { brush as d3_brush } from 'd3-brush';
 import { select } from 'd3-selection';
 import { useCoordination } from '@use-coordination/all';
+import type { WeatherCT } from './weather.js';
 
 const compareNumbers = (a: number, b: number) => a - b;
 
@@ -253,7 +254,7 @@ export function TempPrecipView(props: any) {
   const [
     { maxTempSelection, precipitationSelection },
     { setMaxTempSelection, setPrecipitationSelection },
-  ] = useCoordination(viewUid, ["maxTempSelection", "precipitationSelection"]);
+  ] = useCoordination<WeatherCT>(viewUid, ["maxTempSelection", "precipitationSelection"]);
 
   return (
     <TempPrecipPlot

--- a/examples/plots/src/weather-timeline.tsx
+++ b/examples/plots/src/weather-timeline.tsx
@@ -7,6 +7,7 @@ import {
 } from 'd3-array';
 import { select } from 'd3-selection';
 import { useCoordination } from '@use-coordination/all';
+import type { WeatherCT } from './weather.js';
 
 function TimelinePlot(props: any) {
   const {
@@ -168,7 +169,7 @@ export function TimelineView(props: any) {
   const [
     { maxTempSelection, precipitationSelection },
     { setMaxTempSelection, setPrecipitationSelection },
-  ] = useCoordination(viewUid, ["maxTempSelection", "precipitationSelection"]);
+  ] = useCoordination<WeatherCT>(viewUid, ["maxTempSelection", "precipitationSelection"]);
 
   return (
     <TimelinePlot

--- a/examples/plots/src/weather.tsx
+++ b/examples/plots/src/weather.tsx
@@ -11,10 +11,11 @@ import { WeatherBarsView } from './weather-bars.js';
 import { TempPrecipView } from './weather-temp-precip.js';
 import { TimelineView } from './weather-timeline.js';
 
-const pluginCoordinationTypes = {
+export const pluginCoordinationTypes = {
   maxTempSelection: z.array(z.number()).length(2).nullable(),
   precipitationSelection: z.array(z.number()).length(2).nullable(),
 };
+export type WeatherCT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,

--- a/examples/volumetric/src/niivue-example.tsx
+++ b/examples/volumetric/src/niivue-example.tsx
@@ -34,7 +34,7 @@ function NiivueView(props: any) {
       setAzimuth,
       setElevation,
     },
-  ] = useCoordination(viewUid, ['crosshairX', 'crosshairY', 'crosshairZ', 'azimuth', 'elevation']);
+  ] = useCoordination<CT>(viewUid, ['crosshairX', 'crosshairY', 'crosshairZ', 'azimuth', 'elevation']);
 
   const [options, setOptions] = useImmer<NVROptions>({
     isOrientCube: true,
@@ -67,6 +67,7 @@ const pluginCoordinationTypes = {
   azimuth: z.number(),
   elevation: z.number(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = defineSpec({
   key: 1,

--- a/packages/core/src/coordination-type-utils.test.ts
+++ b/packages/core/src/coordination-type-utils.test.ts
@@ -52,4 +52,61 @@ describe('coordination-type-utils', () => {
       expect(typeof val.scopeA.setSliderValue).toBe('function');
     });
   });
+
+  // These tests validate the precise-key behavior that the `const P` generic parameter
+  // on useCoordination enables. `const P` causes TypeScript to infer literal tuple types
+  // from the parameters array without requiring `as const` at call sites. The result is
+  // that PickValues/PickSetters only expose the requested keys — not all keys of CTypes.
+  // Without `const P`, TypeScript would widen to `string[]` and the return type would
+  // collapse to `Record<string, unknown>`, making all keys always present.
+  describe('PickValues/PickSetters expose only requested keys', () => {
+    it('values object only has requested keys — unrequested keys are absent', () => {
+      // Requesting only 'sliderValue'; 'colorValue' and 'label' must not appear.
+      type Values = PickValues<T, ['sliderValue']>;
+      const val: Values = { sliderValue: 10 };
+      expect(val.sliderValue).toBe(10);
+      // @ts-expect-error colorValue was not requested
+      val.colorValue;
+      // @ts-expect-error label was not requested
+      val.label;
+    });
+
+    it('setters object only has requested setters — unrequested setters are absent', () => {
+      type Setters = PickSetters<T, ['sliderValue']>;
+      const setters: Setters = { setSliderValue: (_v: number) => {} };
+      expect(typeof setters.setSliderValue).toBe('function');
+      // @ts-expect-error setColorValue was not requested
+      setters.setColorValue;
+      // @ts-expect-error setLabel was not requested
+      setters.setLabel;
+    });
+
+    it('setter argument type matches the Zod schema — wrong type is rejected', () => {
+      type Setters = PickSetters<T, ['sliderValue']>;
+      const setters: Setters = { setSliderValue: (_v: number) => {} };
+      // Correct type passes:
+      setters.setSliderValue(42);
+      // @ts-expect-error string is not assignable to number
+      setters.setSliderValue('wrong');
+    });
+
+    it('nullable Zod schema produces number[] | null value type', () => {
+      // colorValue is z.array(z.number()).nullable() → number[] | null
+      type Values = PickValues<T, ['colorValue']>;
+      const val: Values = { colorValue: null };
+      const col: number[] | null = val.colorValue;
+      expect(col).toBeNull();
+    });
+
+    it('multiple requested keys are all present with correct types', () => {
+      type Values = PickValues<T, ['sliderValue', 'label', 'colorValue']>;
+      const val: Values = { sliderValue: 1, label: 'hi', colorValue: [255, 0, 0] };
+      const num: number = val.sliderValue;
+      const str: string = val.label;
+      const col: number[] | null = val.colorValue;
+      expect(num).toBe(1);
+      expect(str).toBe('hi');
+      expect(col).toEqual([255, 0, 0]);
+    });
+  });
 });

--- a/packages/core/src/coordination-type-utils.test.ts
+++ b/packages/core/src/coordination-type-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { PickValues, PickSetters, SetterName, PickValuesL1, PickSettersL1 } from './coordination-type-utils.js';
+
+const testTypes = {
+  sliderValue: z.number(),
+  colorValue: z.array(z.number()).nullable(),
+  label: z.string(),
+};
+type T = typeof testTypes;
+
+describe('coordination-type-utils', () => {
+  describe('type-level checks', () => {
+    it('PickValues produces correct value types', () => {
+      type Result = PickValues<T, ['sliderValue', 'label']>;
+      const val: Result = { sliderValue: 42, label: 'hello' };
+      expect(val.sliderValue).toBe(42);
+      expect(val.label).toBe('hello');
+    });
+
+    it('PickValues rejects invalid parameter names', () => {
+      // @ts-expect-error 'nonExistent' is not a key of T
+      type _Bad = PickValues<T, ['nonExistent']>;
+    });
+
+    it('PickSetters produces correct setter names and types', () => {
+      type Result = PickSetters<T, ['sliderValue']>;
+      const setters: Result = { setSliderValue: (_v: number) => {} };
+      expect(typeof setters.setSliderValue).toBe('function');
+    });
+
+    it('PickSetters rejects invalid parameter names', () => {
+      // @ts-expect-error 'nonExistent' is not a key of T
+      type _Bad = PickSetters<T, ['nonExistent']>;
+    });
+
+    it('SetterName capitalizes correctly', () => {
+      type S = SetterName<'sliderValue'>;
+      const name: S = 'setSliderValue';
+      expect(name).toBe('setSliderValue');
+    });
+
+    it('PickValuesL1 wraps in Record<string, ...>', () => {
+      type Result = PickValuesL1<T, ['sliderValue']>;
+      const val: Result = { scopeA: { sliderValue: 10 } };
+      expect(val.scopeA.sliderValue).toBe(10);
+    });
+
+    it('PickSettersL1 wraps in Record<string, ...>', () => {
+      type Result = PickSettersL1<T, ['sliderValue']>;
+      const val: Result = { scopeA: { setSliderValue: (_v: number) => {} } };
+      expect(typeof val.scopeA.setSliderValue).toBe('function');
+    });
+  });
+});

--- a/packages/core/src/coordination-type-utils.ts
+++ b/packages/core/src/coordination-type-utils.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+// Infer TS types from a record of Zod schemas
+export type ZodInferMap<T extends Record<string, z.ZodType>> = {
+  [K in keyof T]: z.infer<T[K]>;
+};
+
+// Pick values for requested parameters
+export type PickValues<
+  CTypes extends Record<string, z.ZodType>,
+  P extends readonly (keyof CTypes)[],
+> = { [K in P[number]]: z.infer<CTypes[K]> };
+
+// Map parameter name to setter name: "foo" → "setFoo"
+export type SetterName<S extends string> = `set${Capitalize<S>}`;
+
+// Build setters record with correct value types
+export type PickSetters<
+  CTypes extends Record<string, z.ZodType>,
+  P extends readonly (keyof CTypes & string)[],
+> = { [K in P[number] as SetterName<K>]: (value: z.infer<CTypes[K]>) => void };
+
+// L1 wrappers (scope name → typed inner record)
+export type PickValuesL1<
+  CTypes extends Record<string, z.ZodType>,
+  P extends readonly (keyof CTypes & string)[],
+> = Record<string, PickValues<CTypes, P>>;
+
+export type PickSettersL1<
+  CTypes extends Record<string, z.ZodType>,
+  P extends readonly (keyof CTypes & string)[],
+> = Record<string, PickSetters<CTypes, P>>;
+
+// L2 wrappers (two levels of scope nesting)
+export type PickValuesL2<
+  CTypes extends Record<string, z.ZodType>,
+  P extends readonly (keyof CTypes & string)[],
+> = Record<string, Record<string, PickValues<CTypes, P>>>;
+
+export type PickSettersL2<
+  CTypes extends Record<string, z.ZodType>,
+  P extends readonly (keyof CTypes & string)[],
+> = Record<string, Record<string, PickSetters<CTypes, P>>>;

--- a/packages/core/src/hooks.tsx
+++ b/packages/core/src/hooks.tsx
@@ -5,9 +5,15 @@ import { create, useStore } from 'zustand';
 import { useShallow } from 'zustand/shallow';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { cloneDeep } from 'lodash-es';
+import { z } from 'zod';
 import { capitalize } from '@use-coordination/utils';
 import { getCoordinationSpaceAndScopes } from '@use-coordination/config';
 import { CmvConfigObject } from './prop-types.js';
+import type {
+  PickValues, PickSetters,
+  PickValuesL1, PickSettersL1,
+  PickValuesL2, PickSettersL2,
+} from './coordination-type-utils.js';
 
 
 type SetCoordinationValueParamsNotByType = {
@@ -480,7 +486,10 @@ export function useViewMapping(viewUid: string) {
  * to scope names.
  * @returns {object} Object containing all coordination values.
  */
-export function _useInitialCoordination(coordinationScopes: Record<string, any>, parameters: string[]) {
+export function _useInitialCoordination<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(coordinationScopes: Record<string, any>, parameters: P): PickValues<CTypes, P> {
   const values = useCoordinationStoreShallow((state) => {
     const { coordinationSpace } = state.initialSpec;
     return Object.fromEntries(parameters.map((parameter) => {
@@ -491,7 +500,7 @@ export function _useInitialCoordination(coordinationScopes: Record<string, any>,
       return [parameter, undefined];
     }));
   });
-  return values;
+  return values as PickValues<CTypes, P>;
 }
 
 /**
@@ -501,9 +510,12 @@ export function _useInitialCoordination(coordinationScopes: Record<string, any>,
  * @param parameters 
  * @returns 
  */
-export function useInitialCoordination(viewUid: string, parameters: string[]) {
+export function useInitialCoordination<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(viewUid: string, parameters: P): PickValues<CTypes, P> {
   const [coordinationScopes] = useViewMapping(viewUid);
-  return _useInitialCoordination(coordinationScopes, parameters);
+  return _useInitialCoordination<CTypes, P>(coordinationScopes, parameters);
 }
 
 
@@ -523,7 +535,10 @@ export function useInitialCoordination(viewUid: string, parameters: string[]) {
  * functions for the values in `values`, named with a "set"
  * prefix.
  */
-export function _useCoordination(coordinationScopes: Record<string, string | string[]>, parameters: string[]) {
+export function _useCoordination<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(coordinationScopes: Record<string, string | string[]>, parameters: P): [PickValues<CTypes, P>, PickSetters<CTypes, P>] {
   const setCoordinationValue = useCoordinationStore((state) => state.setCoordinationValue);
 
   const values = useCoordinationStoreShallow((state) => {
@@ -551,27 +566,36 @@ export function _useCoordination(coordinationScopes: Record<string, string | str
   // eslint-disable-next-line react-hooks/exhaustive-deps
   })), [coordinationScopes]);
 
-  return [values, setters];
+  return [values, setters] as [PickValues<CTypes, P>, PickSetters<CTypes, P>];
 }
 
-export function useCoordination(viewUid: string, parameters: string[]) {
+export function useCoordination<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(viewUid: string, parameters: P): [PickValues<CTypes, P>, PickSetters<CTypes, P>] {
   const [coordinationScopes] = useViewMapping(viewUid);
-  return _useCoordination(coordinationScopes, parameters);
+  return _useCoordination<CTypes, P>(coordinationScopes, parameters);
 }
 
-export function _useCoordinationScopesAll(coordinationScopes: Record<string, string | string[]>, parameter: string) {
+export function _useCoordinationScopesAll<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(coordinationScopes: Record<string, string | string[]>, parameter: keyof CTypes & string) {
   return useMemo(() => {
     const scopes = coordinationScopes[parameter];
     return Array.isArray(scopes) ? scopes : [scopes];
   }, [parameter, coordinationScopes]);
 }
 
-export function useCoordinationScopesAll(viewUid: string, parameter: string) {
+export function useCoordinationScopesAll<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(viewUid: string, parameter: keyof CTypes & string) {
   const [coordinationScopes] = useViewMapping(viewUid);
-  return _useCoordinationScopesAll(coordinationScopes, parameter);
+  return _useCoordinationScopesAll<CTypes>(coordinationScopes, parameter);
 }
 
-export function _useCoordinationScopes(coordinationScopes: Record<string, string | string[]>, parameter: string) {
+export function _useCoordinationScopes<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(coordinationScopes: Record<string, string | string[]>, parameter: keyof CTypes & string) {
   const scopes = getParameterScope(coordinationScopes, parameter);
 
   // Return array of coordination scopes,
@@ -594,14 +618,18 @@ export function _useCoordinationScopes(coordinationScopes: Record<string, string
   return nonNullScopes;
 }
 
-export function useCoordinationScopes(viewUid: string, parameter: string) {
+export function useCoordinationScopes<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(viewUid: string, parameter: keyof CTypes & string) {
   const [coordinationScopes] = useViewMapping(viewUid);
-  return _useCoordinationScopes(coordinationScopes, parameter);
+  return _useCoordinationScopes<CTypes>(coordinationScopes, parameter);
 }
 
-export function _useCoordinationScopesL1All(
+export function _useCoordinationScopesL1All<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, any>,
-  byType: string, parameter: string,
+  byType: keyof CTypes & string, parameter: keyof CTypes & string,
 ) {
   return useMemo(() => {
     const scopes = getParameterScope(coordinationScopes, byType);
@@ -630,14 +658,18 @@ export function _useCoordinationScopesL1All(
   }, [parameter, byType, coordinationScopes, coordinationScopesBy]);
 }
 
-export function useCoordinationScopesL1All(viewUid: string, byType: string, parameter: string) {
+export function useCoordinationScopesL1All<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(viewUid: string, byType: keyof CTypes & string, parameter: keyof CTypes & string) {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
-  return _useCoordinationScopesL1All(coordinationScopes, coordinationScopesBy, byType, parameter);
+  return _useCoordinationScopesL1All<CTypes>(coordinationScopes, coordinationScopesBy, byType, parameter);
 }
 
-export function _useCoordinationScopesL1(
+export function _useCoordinationScopesL1<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, any>,
-  byType: string, parameter: string,
+  byType: keyof CTypes & string, parameter: keyof CTypes & string,
 ) {
   const scopes = getParameterScope(coordinationScopes, byType);
 
@@ -704,12 +736,17 @@ export function _useCoordinationScopesL1(
   }, [parameter, byType, scopes, coordinationScopes, coordinationScopesBy, parameterSpace, byTypeSpace]);
 }
 
-export function useCoordinationScopesL1(viewUid: string, byType: string, parameter: string) {
+export function useCoordinationScopesL1<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+>(viewUid: string, byType: keyof CTypes & string, parameter: keyof CTypes & string) {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
-  return _useCoordinationScopesL1(coordinationScopes, coordinationScopesBy, byType, parameter);
+  return _useCoordinationScopesL1<CTypes>(coordinationScopes, coordinationScopesBy, byType, parameter);
 }
 
-export function _useCoordinationObject(coordinationScopes: Record<string, string | string[]>, parameter: string) {
+export function _useCoordinationObject<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  K extends keyof CTypes & string = keyof CTypes & string,
+>(coordinationScopes: Record<string, string | string[]>, parameter: K): Record<string, z.infer<CTypes[K]>> {
   const scopes = getParameterScope(coordinationScopes, parameter);
 
   // Mapping from dataset coordination scope name to dataset uid
@@ -727,12 +764,15 @@ export function _useCoordinationObject(coordinationScopes: Record<string, string
     }).filter(([k, v]) => v !== undefined));
   });
 
-  return vals;
+  return vals as Record<string, z.infer<CTypes[K]>>;
 }
 
-export function useCoordinationObject(viewUid: string, parameter: string) {
+export function useCoordinationObject<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  K extends keyof CTypes & string = keyof CTypes & string,
+>(viewUid: string, parameter: K): Record<string, z.infer<CTypes[K]>> {
   const [coordinationScopes] = useViewMapping(viewUid);
-  return _useCoordinationObject(coordinationScopes, parameter);
+  return _useCoordinationObject<CTypes, K>(coordinationScopes, parameter);
 }
 
 /**
@@ -749,10 +789,13 @@ export function useCoordinationObject(viewUid: string, parameter: string) {
  * and cSetters is a mapping from coordination scope name to { setCoordinationType }
  * setter functions.
  */
-export function _useCoordinationL1(
+export function _useCoordinationL1<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, Record<string, any>>,
-  byType: string, parameters: string[],
-) {
+  byType: keyof CTypes & string, parameters: P,
+): [PickValuesL1<CTypes, P>, PickSettersL1<CTypes, P>] {
   const setCoordinationValue = useCoordinationStore((state) => state.setCoordinationValue);
 
   const parameterSpaces = useCoordinationStoreShallow((state) => {
@@ -822,12 +865,15 @@ export function _useCoordinationL1(
   // parameters is assumed to be a constant array.
   }, [coordinationScopes]);
 
-  return [values, setters];
+  return [values, setters] as [PickValuesL1<CTypes, P>, PickSettersL1<CTypes, P>];
 }
 
-export function useCoordinationL1(viewUid: string, byType: string, parameters: string[]) {
+export function useCoordinationL1<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(viewUid: string, byType: keyof CTypes & string, parameters: P): [PickValuesL1<CTypes, P>, PickSettersL1<CTypes, P>] {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
-  return _useCoordinationL1(coordinationScopes, coordinationScopesBy, byType, parameters);
+  return _useCoordinationL1<CTypes, P>(coordinationScopes, coordinationScopesBy, byType, parameters);
 }
 
 /**
@@ -838,10 +884,13 @@ export function useCoordinationL1(viewUid: string, byType: string, parameters: s
  * @param {string} secondaryType The second-level coordination type, such as spatialImageChannel.
  * @returns The results of useCoordinationL1.
  */
-export function _useCoordinationL2(
+export function _useCoordinationL2<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, any>,
-  primaryType: string, secondaryType: string, parameters: string[], 
-) {
+  primaryType: keyof CTypes & string, secondaryType: keyof CTypes & string, parameters: P,
+): [PickValuesL2<CTypes, P>, PickSettersL2<CTypes, P>] {
   const coordinationScopesFake = useMemo(() => {
     if (coordinationScopesBy?.[primaryType]?.[secondaryType]) {
       return {
@@ -922,12 +971,15 @@ export function _useCoordinationL2(
     return result;
   }, [flatSetters]);
 
-  return [nestedValues, nestedSetters];
+  return [nestedValues, nestedSetters] as [PickValuesL2<CTypes, P>, PickSettersL2<CTypes, P>];
 }
 
-export function useCoordinationL2(viewUid: string, primaryType: string, secondaryType: string, parameters: string[]) {
+export function useCoordinationL2<
+  CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+>(viewUid: string, primaryType: keyof CTypes & string, secondaryType: keyof CTypes & string, parameters: P): [PickValuesL2<CTypes, P>, PickSettersL2<CTypes, P>] {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
-  return _useCoordinationL2(coordinationScopes, coordinationScopesBy, primaryType, secondaryType, parameters);
+  return _useCoordinationL2<CTypes, P>(coordinationScopes, coordinationScopesBy, primaryType, secondaryType, parameters);
 }
 
 /**

--- a/packages/core/src/hooks.tsx
+++ b/packages/core/src/hooks.tsx
@@ -488,10 +488,14 @@ export function useViewMapping(viewUid: string) {
  */
 export function _useInitialCoordination<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
 >(coordinationScopes: Record<string, any>, parameters: P): PickValues<CTypes, P> {
   const values = useCoordinationStoreShallow((state) => {
     const { coordinationSpace } = state.initialSpec;
+    // TypeScript can only do limited things for Object.fromEntries:
+    // References:
+    // - https://stackoverflow.com/a/69019874
+    // - https://github.com/microsoft/TypeScript/issues/35745
     return Object.fromEntries(parameters.map((parameter) => {
       if (coordinationSpace && coordinationSpace[parameter]) {
         const value = coordinationSpace[parameter][coordinationScopes[parameter]];
@@ -500,6 +504,7 @@ export function _useInitialCoordination<
       return [parameter, undefined];
     }));
   });
+  
   return values as PickValues<CTypes, P>;
 }
 
@@ -512,7 +517,7 @@ export function _useInitialCoordination<
  */
 export function useInitialCoordination<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
 >(viewUid: string, parameters: P): PickValues<CTypes, P> {
   const [coordinationScopes] = useViewMapping(viewUid);
   return _useInitialCoordination<CTypes, P>(coordinationScopes, parameters);
@@ -537,7 +542,7 @@ export function useInitialCoordination<
  */
 export function _useCoordination<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
 >(coordinationScopes: Record<string, string | string[]>, parameters: P): [PickValues<CTypes, P>, PickSetters<CTypes, P>] {
   const setCoordinationValue = useCoordinationStore((state) => state.setCoordinationValue);
 
@@ -571,7 +576,7 @@ export function _useCoordination<
 
 export function useCoordination<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
 >(viewUid: string, parameters: P): [PickValues<CTypes, P>, PickSetters<CTypes, P>] {
   const [coordinationScopes] = useViewMapping(viewUid);
   return _useCoordination<CTypes, P>(coordinationScopes, parameters);
@@ -579,7 +584,7 @@ export function useCoordination<
 
 export function _useCoordinationScopesAll<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
->(coordinationScopes: Record<string, string | string[]>, parameter: keyof CTypes & string) {
+>(coordinationScopes: Record<string, string | string[]>, parameter: Extract<keyof CTypes, string>) {
   return useMemo(() => {
     const scopes = coordinationScopes[parameter];
     return Array.isArray(scopes) ? scopes : [scopes];
@@ -588,14 +593,14 @@ export function _useCoordinationScopesAll<
 
 export function useCoordinationScopesAll<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
->(viewUid: string, parameter: keyof CTypes & string) {
+>(viewUid: string, parameter: Extract<keyof CTypes, string>) {
   const [coordinationScopes] = useViewMapping(viewUid);
   return _useCoordinationScopesAll<CTypes>(coordinationScopes, parameter);
 }
 
 export function _useCoordinationScopes<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
->(coordinationScopes: Record<string, string | string[]>, parameter: keyof CTypes & string) {
+>(coordinationScopes: Record<string, string | string[]>, parameter: Extract<keyof CTypes, string>) {
   const scopes = getParameterScope(coordinationScopes, parameter);
 
   // Return array of coordination scopes,
@@ -620,7 +625,7 @@ export function _useCoordinationScopes<
 
 export function useCoordinationScopes<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
->(viewUid: string, parameter: keyof CTypes & string) {
+>(viewUid: string, parameter: Extract<keyof CTypes, string>) {
   const [coordinationScopes] = useViewMapping(viewUid);
   return _useCoordinationScopes<CTypes>(coordinationScopes, parameter);
 }
@@ -629,7 +634,7 @@ export function _useCoordinationScopesL1All<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
 >(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, any>,
-  byType: keyof CTypes & string, parameter: keyof CTypes & string,
+  byType: Extract<keyof CTypes, string>, parameter: Extract<keyof CTypes, string>,
 ) {
   return useMemo(() => {
     const scopes = getParameterScope(coordinationScopes, byType);
@@ -660,7 +665,7 @@ export function _useCoordinationScopesL1All<
 
 export function useCoordinationScopesL1All<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
->(viewUid: string, byType: keyof CTypes & string, parameter: keyof CTypes & string) {
+>(viewUid: string, byType: Extract<keyof CTypes, string>, parameter: Extract<keyof CTypes, string>) {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
   return _useCoordinationScopesL1All<CTypes>(coordinationScopes, coordinationScopesBy, byType, parameter);
 }
@@ -669,7 +674,7 @@ export function _useCoordinationScopesL1<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
 >(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, any>,
-  byType: keyof CTypes & string, parameter: keyof CTypes & string,
+  byType: Extract<keyof CTypes, string>, parameter: Extract<keyof CTypes, string>,
 ) {
   const scopes = getParameterScope(coordinationScopes, byType);
 
@@ -738,14 +743,14 @@ export function _useCoordinationScopesL1<
 
 export function useCoordinationScopesL1<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
->(viewUid: string, byType: keyof CTypes & string, parameter: keyof CTypes & string) {
+>(viewUid: string, byType: Extract<keyof CTypes, string>, parameter: Extract<keyof CTypes, string>) {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
   return _useCoordinationScopesL1<CTypes>(coordinationScopes, coordinationScopesBy, byType, parameter);
 }
 
 export function _useCoordinationObject<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  K extends keyof CTypes & string = keyof CTypes & string,
+  K extends Extract<keyof CTypes, string> = Extract<keyof CTypes, string>,
 >(coordinationScopes: Record<string, string | string[]>, parameter: K): Record<string, z.infer<CTypes[K]>> {
   const scopes = getParameterScope(coordinationScopes, parameter);
 
@@ -769,7 +774,7 @@ export function _useCoordinationObject<
 
 export function useCoordinationObject<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  K extends keyof CTypes & string = keyof CTypes & string,
+  K extends Extract<keyof CTypes, string> = Extract<keyof CTypes, string>,
 >(viewUid: string, parameter: K): Record<string, z.infer<CTypes[K]>> {
   const [coordinationScopes] = useViewMapping(viewUid);
   return _useCoordinationObject<CTypes, K>(coordinationScopes, parameter);
@@ -791,10 +796,10 @@ export function useCoordinationObject<
  */
 export function _useCoordinationL1<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
 >(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, Record<string, any>>,
-  byType: keyof CTypes & string, parameters: P,
+  byType: Extract<keyof CTypes, string>, parameters: P,
 ): [PickValuesL1<CTypes, P>, PickSettersL1<CTypes, P>] {
   const setCoordinationValue = useCoordinationStore((state) => state.setCoordinationValue);
 
@@ -870,8 +875,8 @@ export function _useCoordinationL1<
 
 export function useCoordinationL1<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
->(viewUid: string, byType: keyof CTypes & string, parameters: P): [PickValuesL1<CTypes, P>, PickSettersL1<CTypes, P>] {
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
+>(viewUid: string, byType: Extract<keyof CTypes, string>, parameters: P): [PickValuesL1<CTypes, P>, PickSettersL1<CTypes, P>] {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
   return _useCoordinationL1<CTypes, P>(coordinationScopes, coordinationScopesBy, byType, parameters);
 }
@@ -886,10 +891,10 @@ export function useCoordinationL1<
  */
 export function _useCoordinationL2<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
 >(
   coordinationScopes: Record<string, string | string[]>, coordinationScopesBy: Record<string, any>,
-  primaryType: keyof CTypes & string, secondaryType: keyof CTypes & string, parameters: P,
+  primaryType: Extract<keyof CTypes, string>, secondaryType: Extract<keyof CTypes, string>, parameters: P,
 ): [PickValuesL2<CTypes, P>, PickSettersL2<CTypes, P>] {
   const coordinationScopesFake = useMemo(() => {
     if (coordinationScopesBy?.[primaryType]?.[secondaryType]) {
@@ -976,8 +981,8 @@ export function _useCoordinationL2<
 
 export function useCoordinationL2<
   CTypes extends Record<string, z.ZodType> = Record<string, z.ZodType>,
-  const P extends readonly (keyof CTypes & string)[] = (keyof CTypes & string)[],
->(viewUid: string, primaryType: keyof CTypes & string, secondaryType: keyof CTypes & string, parameters: P): [PickValuesL2<CTypes, P>, PickSettersL2<CTypes, P>] {
+  const P extends readonly (Extract<keyof CTypes, string>)[] = (Extract<keyof CTypes, string>)[],
+>(viewUid: string, primaryType: Extract<keyof CTypes, string>, secondaryType: Extract<keyof CTypes, string>, parameters: P): [PickValuesL2<CTypes, P>, PickSettersL2<CTypes, P>] {
   const [coordinationScopes, coordinationScopesBy] = useViewMapping(viewUid);
   return _useCoordinationL2<CTypes, P>(coordinationScopes, coordinationScopesBy, primaryType, secondaryType, parameters);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,3 +35,13 @@ export {
 export { ZodCoordinationProvider } from './ZodCoordinationProvider.js';
 export { ZodErrorBoundary } from './ZodErrorBoundary.js';
 export { defineSpec } from './generic-types.js';
+export type {
+  ZodInferMap,
+  PickValues,
+  PickSetters,
+  SetterName,
+  PickValuesL1,
+  PickSettersL1,
+  PickValuesL2,
+  PickSettersL2,
+} from './coordination-type-utils.js';

--- a/sites/demo/src/Demo.tsx
+++ b/sites/demo/src/Demo.tsx
@@ -98,7 +98,7 @@ const SliderInputContainer = ({
     sliderValue,
   }, {
     setSliderValue,
-  }] = useCoordination(viewUid, ['sliderValue']);
+  }] = useCoordination<CT>(viewUid, ['sliderValue']);
 
   const renderCounter  = useRef(0);
   renderCounter.current = renderCounter.current + 1;
@@ -130,6 +130,7 @@ const SliderInputContainer = ({
 const pluginCoordinationTypes = {
   sliderValue: z.number(),
 };
+type CT = typeof pluginCoordinationTypes;
 
 const initialSpec = {
   key: 1,


### PR DESCRIPTION
There is a bunch of `as` going on in the hook return statements, but it seems to be challenging to preserve types through Object.fromEntries and Object.entries.