### PR TITLE
CmvConfig to typescript

### DIFF
--- a/.changeset/slimy-rabbits-drum.md
+++ b/.changeset/slimy-rabbits-drum.md
@@ -1,0 +1,7 @@
+---
+"@use-coordination/config": patch
+"@use-coordination/types": patch
+"@use-coordination/core": patch
+---
+
+Add a shared `@use-coordination/types` sub-package. Improve type-checking in CmvConfig.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,6 +29,7 @@
     "@use-coordination/utils": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "zod": "^4.3.0"
   }
 }

--- a/packages/config/src/CmvConfig.test.ts
+++ b/packages/config/src/CmvConfig.test.ts
@@ -799,8 +799,8 @@ describe('src/api/CmvConfig.js', () => {
         },
       });
 
-      // Return type of addCoordination is CmvConfigCoordinationScope[].
-      expectTypeOf(config.addCoordination(['embeddingZoom'])).toEqualTypeOf<CmvConfigCoordinationScope[]>();
+      // Return type of addCoordination is a typed tuple matching the inferred value type per key.
+      expectTypeOf(config.addCoordination(['embeddingZoom'])).toEqualTypeOf<[CmvConfigCoordinationScope<number | null>]>();
 
       // Return type of addView is CmvConfigView<CT>.
       expectTypeOf(config.addView('x')).toEqualTypeOf<CmvConfigView<CT>>();
@@ -835,6 +835,15 @@ describe('src/api/CmvConfig.js', () => {
         // @ts-expect-error 10 is not assignable to string (z.infer<z.ZodString>)
         embeddingType: 10,
       });
+
+      // @ts-expect-error 10 is not assignable to string (z.infer<z.ZodString>)
+      config2.setCoordinationValue('embeddingType', 'A', 10);
+
+      // @ts-expect-error
+      config2.linkViews([view2], ['embeddingType'], [10]);
+      config2.linkViews([view2], ['embeddingType'], ['test']);
+      // @ts-expect-error
+      config2.linkViews([view2], ['embeddingType', 'embeddingZoom'], ['test', 'test']);
     });
   });
 });

--- a/packages/config/src/CmvConfig.test.ts
+++ b/packages/config/src/CmvConfig.test.ts
@@ -772,6 +772,7 @@ describe('src/api/CmvConfig.js', () => {
         embeddingZoom: z.number().nullable(),
         embeddingType: z.string(),
         dataset: z.string(),
+        imageLayer: z.string(),
       };
       type CT = typeof pluginCoordinationTypes;
 
@@ -844,6 +845,16 @@ describe('src/api/CmvConfig.js', () => {
       config2.linkViews([view2], ['embeddingType'], ['test']);
       // @ts-expect-error
       config2.linkViews([view2], ['embeddingType', 'embeddingZoom'], ['test', 'test']);
+
+      config2.linkViewsByObject([view2], {
+        // @ts-expect-error
+        embeddingZoom: 'test',
+        imageLayer: CL<CT>([{
+          // @ts-expect-error
+          notAType: 0,
+          embeddingType: 'test',
+        }])
+      });
     });
   });
 });

--- a/packages/config/src/CmvConfig.test.ts
+++ b/packages/config/src/CmvConfig.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { z } from 'zod';
 import {
   CmvConfig,
+  CmvConfigView,
+  CmvConfigMetaCoordinationScope,
+  CmvConfigCoordinationScope,
   CL,
 } from './CmvConfig.js';
 
@@ -701,7 +705,7 @@ describe('src/api/CmvConfig.js', () => {
         key: 'My config',
       });
     });
-    
+
     it('can load a view config from JSON', () => {
       const config = new CmvConfig('My config');
       const v1 = config.addView('spatial');
@@ -761,6 +765,75 @@ describe('src/api/CmvConfig.js', () => {
           },
         },
         key: 'My config',
+      });
+    });
+    it('generic CT param constrains coordination type names', () => {
+      const pluginCoordinationTypes = {
+        embeddingZoom: z.number().nullable(),
+        embeddingType: z.string(),
+        dataset: z.string(),
+      };
+      type CT = typeof pluginCoordinationTypes;
+
+      // Valid coordination types are accepted at runtime and produce correct JSON.
+      const config = new CmvConfig<CT>('My config');
+      const [zoomScope] = config.addCoordination(['embeddingZoom']);
+      zoomScope.setValue(10);
+      const pca = config.addView('pca');
+      pca.useCoordination([zoomScope]);
+      config.linkViews([pca], ['embeddingType'], ['PCA']);
+
+      expect(config.toJSON()).toEqual({
+        key: 'My config',
+        coordinationSpace: {
+          embeddingZoom: { A: 10 },
+          embeddingType: { A: 'PCA' },
+        },
+        viewCoordination: {
+          pca: {
+            coordinationScopes: {
+              embeddingZoom: 'A',
+              embeddingType: 'A',
+            },
+          },
+        },
+      });
+
+      // Return type of addCoordination is CmvConfigCoordinationScope[].
+      expectTypeOf(config.addCoordination(['embeddingZoom'])).toEqualTypeOf<CmvConfigCoordinationScope[]>();
+
+      // Return type of addView is CmvConfigView<CT>.
+      expectTypeOf(config.addView('x')).toEqualTypeOf<CmvConfigView<CT>>();
+      // Return type of addMetaCoordination is CmvConfigMetaCoordinationScope<CT>.
+      expectTypeOf(config.addMetaCoordination()).toEqualTypeOf<CmvConfigMetaCoordinationScope<CT>>();
+
+      // ProcessedLevelOf is CT-branded: scopes from one CT cannot be passed to views/meta-scopes of another CT.
+      const configB = new CmvConfig<{ otherType: z.ZodString }>('config B');
+      const viewB = configB.addView('v');
+      const metaB = configB.addMetaCoordination();
+      const scopesA = config.addCoordinationByObject({ embeddingZoom: 10 });
+      // @ts-expect-error scopes from CT cannot be used with a CmvConfigView<different CT>
+      viewB.useCoordinationByObject(scopesA);
+      // @ts-expect-error scopes from CT cannot be used with a CmvConfigMetaCoordinationScope<different CT>
+      metaB.useCoordinationByObject(scopesA);
+
+      // Invalid coordination types are rejected by TypeScript.
+      const config2 = new CmvConfig<CT>('type checks');
+      const view2 = config2.addView('v');
+      // @ts-expect-error 'notAType' is not a key of CT
+      config2.addCoordination(['notAType']);
+      // @ts-expect-error 'notAType' is not a key of CT
+      config2.linkViews([view2], ['notAType']);
+      // @ts-expect-error 'notAType' is not a key of CT
+      config2.setCoordinationValue('notAType', 'A', 0);
+      // @ts-expect-error 'notAType' is not a key of CT
+      config2.addCoordinationByObject({ notAType: 0 });
+      // @ts-expect-error 'notAType' is not a key of CT
+      config2.linkViewsByObject([view2], { notAType: CL([{}]) });
+
+      config2.linkViewsByObject([view2], {
+        // @ts-expect-error 10 is not assignable to string (z.infer<z.ZodString>)
+        embeddingType: 10,
       });
     });
   });

--- a/packages/config/src/CmvConfig.ts
+++ b/packages/config/src/CmvConfig.ts
@@ -346,17 +346,17 @@ export function CL(value: CoordinationInput | CoordinationInput[]): Coordination
 /**
  * Class representing a coordination scope in the coordination space.
  */
-export class CmvConfigCoordinationScope {
+export class CmvConfigCoordinationScope<V = CoordinationValue> {
   cType: CoordinationType;
   cScope: CoordinationScopeName;
-  cValue: CoordinationValue;
+  cValue: V | null;
 
   /**
    * Construct a new coordination scope instance.
    * @param {string} cType The coordination type for this coordination scope.
    * @param {string} cScope The name of the coordination scope.
    */
-  constructor(cType: CoordinationType, cScope: CoordinationScopeName, cValue: CoordinationValue = null) {
+  constructor(cType: CoordinationType, cScope: CoordinationScopeName, cValue: V | null = null) {
     this.cType = cType;
     this.cScope = cScope;
     this.cValue = cValue;
@@ -364,10 +364,10 @@ export class CmvConfigCoordinationScope {
 
   /**
    * Set the coordination value of the coordination scope.
-   * @param {any} cValue The value to set.
+   * @param {V} cValue The value to set.
    * @returns {CmvConfigCoordinationScope} This, to allow chaining.
    */
-  setValue(cValue: CoordinationValue): this {
+  setValue(cValue: V): this {
     this.cValue = cValue;
     return this;
   }
@@ -480,7 +480,9 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
    * @param {string[]} cTypes A variable number of coordination type names.
    * @returns {CmvConfigCoordinationScope[]} An array of coordination scope instances.
    */
-  addCoordination(cTypes: Extract<keyof CT, string>[]): CmvConfigCoordinationScope[] {
+  addCoordination<const K extends Extract<keyof CT, string>[]>(
+    cTypes: K,
+  ): { [I in keyof K]: CmvConfigCoordinationScope<z.infer<CT[K[I] & keyof CT]>> } {
     const result: CmvConfigCoordinationScope[] = [];
     cTypes.forEach((cType) => {
       const prevScopes = (
@@ -495,7 +497,7 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
       this.config.coordinationSpace[scope.cType][scope.cScope] = scope;
       result.push(scope);
     });
-    return result;
+    return result as unknown as { [I in keyof K]: CmvConfigCoordinationScope<z.infer<CT[K[I] & keyof CT]>> };
   }
 
   /**
@@ -620,7 +622,7 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
             result[cType] = nextLevelOrInitialValue.getCached()!;
           } else if (Array.isArray(nextLevel)) {
             const processedLevel: ScopeWithChildren[] = nextLevel.map((nextEl) => {
-              const [dummyScope] = this.addCoordination([cType as Extract<keyof CT, string>]);
+              const [dummyScope] = this.addCoordination([cType as Extract<keyof CT, string>]) as unknown as CmvConfigCoordinationScope[];
               // TODO: set a better initial value for dummy cases.
               dummyScope.setValue('__dummy__');
               return {
@@ -632,7 +634,7 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
             result[cType] = processedLevel;
           } else {
             const nextEl = nextLevel;
-            const [dummyScope] = this.addCoordination([cType as Extract<keyof CT, string>]);
+            const [dummyScope] = this.addCoordination([cType as Extract<keyof CT, string>]) as unknown as CmvConfigCoordinationScope[];
             // TODO: set a better initial value for dummy cases.
             dummyScope.setValue('__dummy__');
             const processedLevel: ScopeWithChildren = {
@@ -669,7 +671,11 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
    * Should have the same length as the cTypes array. Optional.
    * @returns {CmvConfig} This, to allow chaining.
    */
-  linkViews(views: CmvConfigView<CT>[], cTypes: Extract<keyof CT, string>[], cValues: CoordinationValue[] | null = null): this {
+  linkViews<const K extends Extract<keyof CT, string>[]>(
+    views: CmvConfigView<CT>[],
+    cTypes: K,
+    cValues: { [I in keyof K]: z.infer<CT[K[I] & keyof CT]> } | null = null,
+  ): this {
     const cScopes = this.addCoordination(cTypes);
     views.forEach((view) => {
       cScopes.forEach((cScope) => {
@@ -738,16 +744,16 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
    * @param {any} cValue The initial value for the coordination scope.
    * @returns {CmvConfigCoordinationScope} A coordination scope instance.
    */
-  setCoordinationValue(
-    cType: Extract<keyof CT, string>,
+  setCoordinationValue<K extends Extract<keyof CT, string>>(
+    cType: K,
     cScope: CoordinationScopeName,
-    cValue: CoordinationValue,
-  ): CmvConfigCoordinationScope {
-    const scope = new CmvConfigCoordinationScope(cType, cScope, cValue);
+    cValue: z.infer<CT[K]>,
+  ): CmvConfigCoordinationScope<z.infer<CT[K]>> {
+    const scope = new CmvConfigCoordinationScope<z.infer<CT[K]>>(cType, cScope, cValue);
     if (!this.config.coordinationSpace[scope.cType]) {
       this.config.coordinationSpace[scope.cType] = {};
     }
-    this.config.coordinationSpace[scope.cType][scope.cScope] = scope;
+    this.config.coordinationSpace[scope.cType][scope.cScope] = scope as CmvConfigCoordinationScope;
     return scope;
   }
 

--- a/packages/config/src/CmvConfig.ts
+++ b/packages/config/src/CmvConfig.ts
@@ -1,8 +1,89 @@
 /* eslint-disable react-hooks/rules-of-hooks */
+import { z } from 'zod';
 import { META_COORDINATION_SCOPES, META_COORDINATION_SCOPES_BY } from '@use-coordination/constants-internal';
 import { getNextScope, createPrefixedGetNextScopeNumeric } from '@use-coordination/utils';
 
-function useCoordinationByObjectHelper(scopes, coordinationScopes, coordinationScopesBy) {
+type CoordinationScopeName = string;
+type CoordinationType = string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CoordinationValue = any;
+
+type CoordinationScopesMap = Record<CoordinationType, CoordinationScopeName | CoordinationScopeName[]>;
+type CoordinationScopesByMap = Record<
+  CoordinationType,
+  Record<CoordinationType, Record<CoordinationScopeName, CoordinationScopeName | CoordinationScopeName[]>>
+>;
+
+interface ViewJson {
+  coordinationScopes?: CoordinationScopesMap;
+  coordinationScopesBy?: CoordinationScopesByMap;
+  metaCoordinationScopes?: CoordinationScopeName[];
+  metaCoordinationScopesBy?: CoordinationScopeName[];
+}
+
+interface MetaCoordinationJson {
+  coordinationScopes?: Record<CoordinationScopeName, CoordinationScopesMap>;
+  coordinationScopesBy?: Record<CoordinationScopeName, CoordinationScopesByMap>;
+}
+
+export interface CmvConfigJson {
+  key: string | number | undefined;
+  coordinationSpace: Record<CoordinationType, Record<CoordinationScopeName, CoordinationValue>>;
+  viewCoordination: Record<string, ViewJson>;
+  metaCoordination?: MetaCoordinationJson;
+}
+
+interface ScopeWithChildren {
+  scope: CmvConfigCoordinationScope;
+  children?: ProcessedLevel;
+}
+type ProcessedLevelValue = ScopeWithChildren | ScopeWithChildren[];
+type ProcessedLevel = Record<CoordinationType, ProcessedLevelValue>;
+
+// Phantom brand that carries CT through the addCoordinationByObject → useCoordinationByObject pipeline.
+type ProcessedLevelOf<CT extends Record<string, z.ZodTypeAny>> = ProcessedLevel & { readonly __ct?: CT };
+
+type CoordinationInput = Record<
+  CoordinationType,
+  CoordinationLevel | CmvConfigCoordinationScope | CoordinationValue
+>;
+
+type CoordinationInputOf<CT extends Record<string, z.ZodTypeAny>> = {
+  [K in Extract<keyof CT, string>]?: CoordinationLevel | CmvConfigCoordinationScope | z.infer<CT[K]>;
+};
+
+type GetNextScopeFn = (prevScopes: string[]) => string;
+
+interface CmvConfigData<CT extends Record<string, z.ZodTypeAny>> {
+  key: string | number | undefined;
+  coordinationSpace: Record<CoordinationType, Record<CoordinationScopeName, CmvConfigCoordinationScope>>;
+  metaCoordination: {
+    coordinationScopes: Record<CoordinationScopeName, CmvConfigCoordinationScope>;
+    coordinationScopesBy: Record<CoordinationScopeName, CmvConfigCoordinationScope>;
+  };
+  viewCoordination: Record<string, CmvConfigView<CT>>;
+}
+
+interface CmvConfigSpec {
+  key?: string | number;
+  coordinationSpace?: Record<CoordinationType, Record<CoordinationScopeName, CoordinationValue>>;
+  metaCoordination?: {
+    coordinationScopes?: Record<CoordinationScopeName, CoordinationValue>;
+    coordinationScopesBy?: Record<CoordinationScopeName, CoordinationValue>;
+  };
+  viewCoordination?: Record<string, ViewJson>;
+}
+
+interface LinkViewsByObjectOptions {
+  meta?: boolean;
+  scopePrefix?: string | null;
+}
+
+function useCoordinationByObjectHelper(
+  scopes: ProcessedLevel,
+  coordinationScopes: CoordinationScopesMap,
+  coordinationScopesBy: CoordinationScopesByMap,
+): [CoordinationScopesMap, CoordinationScopesByMap] {
   // Set this.coordinationScopes and this.coordinationScopesBy by recursion on `scopes`.
   /*
     // Destructured, `scopes` might look like:
@@ -70,7 +151,12 @@ function useCoordinationByObjectHelper(scopes, coordinationScopes, coordinationS
    */
 
   // Recursive inner function.
-  function processLevel(parentType, parentScope, levelType, levelVal) {
+  function processLevel(
+    parentType: CoordinationType,
+    parentScope: CmvConfigCoordinationScope,
+    levelType: CoordinationType,
+    levelVal: ProcessedLevelValue,
+  ): void {
     if (Array.isArray(levelVal)) {
       // eslint-disable-next-line no-param-reassign
       coordinationScopesBy[parentType] = {
@@ -141,7 +227,9 @@ function useCoordinationByObjectHelper(scopes, coordinationScopes, coordinationS
 /**
  * Class representing a view.
  */
-export class CmvConfigView {
+export class CmvConfigView<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>> {
+  view: ViewJson;
+
   /**
    * Construct a new view instance.
    * @param {object} coordinationScopes A mapping from coordination type
@@ -149,7 +237,12 @@ export class CmvConfigView {
    * @param {object} coordinationScopesBy A mapping from coordination type
    * names to coordination scope names, for multi-level coordination.
    */
-  constructor(coordinationScopes, coordinationScopesBy, metaCoordinationScopes, metaCoordinationScopesBy) {
+  constructor(
+    coordinationScopes: CoordinationScopesMap | undefined,
+    coordinationScopesBy: CoordinationScopesByMap | undefined,
+    metaCoordinationScopes?: CoordinationScopeName[],
+    metaCoordinationScopesBy?: CoordinationScopeName[],
+  ) {
     this.view = {
       coordinationScopes,
       coordinationScopesBy,
@@ -164,12 +257,12 @@ export class CmvConfigView {
    * coordination scope instances.
    * @returns {CmvConfigView} This, to allow chaining.
    */
-  useCoordination(cScopes) {
+  useCoordination(cScopes: CmvConfigCoordinationScope[]): this {
     if (!this.view.coordinationScopes) {
       this.view.coordinationScopes = {};
     }
     cScopes.forEach((cScope) => {
-      this.view.coordinationScopes[cScope.cType] = cScope.cScope;
+      this.view.coordinationScopes![cScope.cType] = cScope.cScope;
     });
     return this;
   }
@@ -180,7 +273,7 @@ export class CmvConfigView {
    * Not intended to be a manually-constructed object.
    * @returns {CmvConfigView} This, to allow chaining.
    */
-  useCoordinationByObject(scopes) {
+  useCoordinationByObject(scopes: ProcessedLevelOf<CT>): this {
     if (!this.view.coordinationScopes) {
       this.view.coordinationScopes = {};
     }
@@ -188,7 +281,7 @@ export class CmvConfigView {
       this.view.coordinationScopesBy = {};
     }
     const [nextCoordinationScopes, nextCoordinationScopesBy] = useCoordinationByObjectHelper(
-      scopes,
+      scopes as ProcessedLevel,
       this.view.coordinationScopes,
       this.view.coordinationScopesBy,
     );
@@ -202,7 +295,7 @@ export class CmvConfigView {
    * @param {CmvConfigMetaCoordinationScope} metaScope A meta coordination scope instance.
    * @returns {CmvConfigView} This, to allow chaining.
    */
-  useMetaCoordination(metaScope) {
+  useMetaCoordination(metaScope: CmvConfigMetaCoordinationScope<CT>): this {
     this.view.metaCoordinationScopes = [
       ...(this.view.metaCoordinationScopes || []),
       metaScope.metaScope.cScope,
@@ -218,32 +311,35 @@ export class CmvConfigView {
   /**
    * @returns {object} This view as a JSON object.
    */
-  toJSON() {
+  toJSON(): ViewJson {
     return this.view;
   }
 }
 
 // would import as CL for convenience
 class CoordinationLevel {
-  constructor(value) {
+  value: CoordinationInput | CoordinationInput[];
+  cachedValue: ProcessedLevelValue | null;
+
+  constructor(value: CoordinationInput | CoordinationInput[]) {
     this.value = value;
     this.cachedValue = null;
   }
 
-  setCached(processedLevel) {
+  setCached(processedLevel: ProcessedLevelValue): void {
     this.cachedValue = processedLevel;
   }
 
-  getCached() {
+  getCached(): ProcessedLevelValue | null {
     return this.cachedValue;
   }
 
-  isCached() {
+  isCached(): boolean {
     return this.cachedValue !== null;
   }
 }
 
-export function CL(value) {
+export function CL(value: CoordinationInput | CoordinationInput[]): CoordinationLevel {
   return new CoordinationLevel(value);
 }
 
@@ -251,12 +347,16 @@ export function CL(value) {
  * Class representing a coordination scope in the coordination space.
  */
 export class CmvConfigCoordinationScope {
+  cType: CoordinationType;
+  cScope: CoordinationScopeName;
+  cValue: CoordinationValue;
+
   /**
    * Construct a new coordination scope instance.
    * @param {string} cType The coordination type for this coordination scope.
    * @param {string} cScope The name of the coordination scope.
    */
-  constructor(cType, cScope, cValue = null) {
+  constructor(cType: CoordinationType, cScope: CoordinationScopeName, cValue: CoordinationValue = null) {
     this.cType = cType;
     this.cScope = cScope;
     this.cValue = cValue;
@@ -267,7 +367,7 @@ export class CmvConfigCoordinationScope {
    * @param {any} cValue The value to set.
    * @returns {CmvConfigCoordinationScope} This, to allow chaining.
    */
-  setValue(cValue) {
+  setValue(cValue: CoordinationValue): this {
     this.cValue = cValue;
     return this;
   }
@@ -278,13 +378,16 @@ export class CmvConfigCoordinationScope {
  * for metaCoordinationScopes and metaCoordinationScopesBy,
  * respectively, in the coordination space.
  */
-export class CmvConfigMetaCoordinationScope {
+export class CmvConfigMetaCoordinationScope<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>> {
+  metaScope: CmvConfigCoordinationScope;
+  metaByScope: CmvConfigCoordinationScope;
+
   /**
    * Construct a new coordination scope instance.
    * @param {string} metaScope The name of the coordination scope for metaCoordinationScopes.
    * @param {string} metaByScope The name of the coordination scope for metaCoordinationScopesBy.
    */
-  constructor(metaScope, metaByScope) {
+  constructor(metaScope: CoordinationScopeName, metaByScope: CoordinationScopeName) {
     this.metaScope = new CmvConfigCoordinationScope(
       META_COORDINATION_SCOPES,
       metaScope,
@@ -301,7 +404,7 @@ export class CmvConfigMetaCoordinationScope {
    * coordination scope instances.
    * @returns {CmvConfigMetaCoordinationScope} This, to allow chaining.
    */
-  useCoordination(cScopes) {
+  useCoordination(cScopes: CmvConfigCoordinationScope[]): this {
     const metaScopesVal = this.metaScope.cValue;
     cScopes.forEach((cScope) => {
       metaScopesVal[cScope.cType] = cScope.cScope;
@@ -315,9 +418,9 @@ export class CmvConfigMetaCoordinationScope {
    * scope instance.
    * @param {object} scopes A value returned by `CmvConfig.addCoordinationByObject`.
    * Not intended to be a manually-constructed object.
-   * @returns {CmvConfigView} This, to allow chaining.
+   * @returns {CmvConfigMetaCoordinationScope} This, to allow chaining.
    */
-  useCoordinationByObject(scopes) {
+  useCoordinationByObject(scopes: ProcessedLevelOf<CT>): this {
     if (!this.metaScope.cValue) {
       this.metaScope.setValue({});
     }
@@ -325,7 +428,7 @@ export class CmvConfigMetaCoordinationScope {
       this.metaByScope.setValue({});
     }
     const [metaScopesVal, metaByScopesVal] = useCoordinationByObjectHelper(
-      scopes,
+      scopes as ProcessedLevel,
       this.metaScope.cValue,
       this.metaByScope.cValue,
     );
@@ -338,13 +441,16 @@ export class CmvConfigMetaCoordinationScope {
 /**
  * Class representing a coordination spec.
  */
-export class CmvConfig {
+export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>> {
+  config: CmvConfigData<CT>;
+  getNextScope: GetNextScopeFn;
+
   /**
    * Construct a new spec instance.
    * @param {object} params An object with named arguments.
    * @param {string|number|undefined} params.key The spec key.
    */
-  constructor(key) {
+  constructor(key: string | number | undefined) {
     this.config = {
       key,
       coordinationSpace: {},
@@ -359,20 +465,11 @@ export class CmvConfig {
 
   /**
    * Add a new view to the spec.
-   * @param {CmvConfigDataset} dataset The dataset instance which defines the data
-   * that will be displayed in the view.
-   * @param {string} component A component name, such as "scatterplot" or "spatial".
-   * @param {object} options Extra options for the component.
-   * @param {number} options.x The x-coordinate for the view in the grid layout.
-   * @param {number} options.y The y-coordinate for the view in the grid layout.
-   * @param {number} options.w The width for the view in the grid layout.
-   * @param {number} options.h The height for the view in the grid layout.
-   * @param {number} options.mapping A convenience parameter for setting the EMBEDDING_TYPE
-   * coordination value. Only applicable if the component is "scatterplot".
+   * @param {string} viewUid The unique identifier for the view.
    * @returns {CmvConfigView} A new view instance.
    */
-  addView(viewUid) {
-    const newView = new CmvConfigView(undefined, undefined);
+  addView(viewUid: string): CmvConfigView<CT> {
+    const newView = new CmvConfigView<CT>(undefined, undefined);
     this.config.viewCoordination[viewUid] = newView;
     return newView;
   }
@@ -383,8 +480,8 @@ export class CmvConfig {
    * @param {string[]} cTypes A variable number of coordination type names.
    * @returns {CmvConfigCoordinationScope[]} An array of coordination scope instances.
    */
-  addCoordination(cTypes) {
-    const result = [];
+  addCoordination(cTypes: Extract<keyof CT, string>[]): CmvConfigCoordinationScope[] {
+    const result: CmvConfigCoordinationScope[] = [];
     cTypes.forEach((cType) => {
       const prevScopes = (
         this.config.coordinationSpace[cType]
@@ -406,7 +503,7 @@ export class CmvConfig {
    * and get a reference to it in the form of a meta coordination scope instance.
    * @returns {CmvConfigMetaCoordinationScope} A new meta coordination scope instance.
    */
-  addMetaCoordination() {
+  addMetaCoordination(): CmvConfigMetaCoordinationScope<CT> {
     const prevMetaScopes = Object.keys(this.config.metaCoordination.coordinationScopes);
     const prevMetaByScopes = Object.keys(this.config.metaCoordination.coordinationScopesBy);
     const metaContainer = new CmvConfigMetaCoordinationScope(
@@ -431,7 +528,7 @@ export class CmvConfig {
    * being either { scope }, { scope, children }, or an array of these. Not intended to be
    * manipulated before being passed to a `useCoordinationByObject` function.
    */
-  addCoordinationByObject(input) {
+  addCoordinationByObject(input: CoordinationInputOf<CT>): ProcessedLevelOf<CT> {
     /*
       // The value for `input` might look like:
       {
@@ -509,8 +606,8 @@ export class CmvConfig {
         // ...
       }
     */
-    const processLevel = (level) => {
-      const result = {};
+    const processLevel = (level: CoordinationInput | null): ProcessedLevel => {
+      const result: ProcessedLevel = {};
       if (level === null) {
         return result;
       }
@@ -520,27 +617,27 @@ export class CmvConfig {
         if (nextLevelOrInitialValue instanceof CoordinationLevel) {
           const nextLevel = nextLevelOrInitialValue.value;
           if (nextLevelOrInitialValue.isCached()) {
-            result[cType] = nextLevelOrInitialValue.getCached();
+            result[cType] = nextLevelOrInitialValue.getCached()!;
           } else if (Array.isArray(nextLevel)) {
-            const processedLevel = nextLevel.map((nextEl) => {
-              const [dummyScope] = this.addCoordination([cType]);
+            const processedLevel: ScopeWithChildren[] = nextLevel.map((nextEl) => {
+              const [dummyScope] = this.addCoordination([cType as Extract<keyof CT, string>]);
               // TODO: set a better initial value for dummy cases.
               dummyScope.setValue('__dummy__');
               return {
                 scope: dummyScope,
-                children: processLevel(nextEl),
+                children: processLevel(nextEl as CoordinationInput),
               };
             });
             nextLevelOrInitialValue.setCached(processedLevel);
             result[cType] = processedLevel;
           } else {
             const nextEl = nextLevel;
-            const [dummyScope] = this.addCoordination([cType]);
+            const [dummyScope] = this.addCoordination([cType as Extract<keyof CT, string>]);
             // TODO: set a better initial value for dummy cases.
             dummyScope.setValue('__dummy__');
-            const processedLevel = {
+            const processedLevel: ScopeWithChildren = {
               scope: dummyScope,
-              children: processLevel(nextEl),
+              children: processLevel(nextEl as CoordinationInput),
             };
             nextLevelOrInitialValue.setCached(processedLevel);
             result[cType] = processedLevel;
@@ -551,7 +648,7 @@ export class CmvConfig {
           if (initialValue instanceof CmvConfigCoordinationScope) {
             result[cType] = { scope: initialValue };
           } else {
-            const [scope] = this.addCoordination([cType]);
+            const [scope] = this.addCoordination([cType as Extract<keyof CT, string>]);
             scope.setValue(initialValue);
             result[cType] = { scope };
           }
@@ -560,7 +657,7 @@ export class CmvConfig {
       return result;
     };
     // Begin recursion.
-    const output = processLevel(input);
+    const output = processLevel(input as CoordinationInput) as ProcessedLevelOf<CT>;
     return output;
   }
 
@@ -572,7 +669,7 @@ export class CmvConfig {
    * Should have the same length as the cTypes array. Optional.
    * @returns {CmvConfig} This, to allow chaining.
    */
-  linkViews(views, cTypes, cValues = null) {
+  linkViews(views: CmvConfigView<CT>[], cTypes: Extract<keyof CT, string>[], cValues: CoordinationValue[] | null = null): this {
     const cScopes = this.addCoordination(cTypes);
     views.forEach((view) => {
       cScopes.forEach((cScope) => {
@@ -603,7 +700,11 @@ export class CmvConfig {
    * coordination scope names. Optional.
    * @returns {CmvConfig} This, to allow chaining.
    */
-  linkViewsByObject(views, input, options = null) {
+  linkViewsByObject(
+    views: CmvConfigView<CT>[],
+    input: CoordinationInputOf<CT>,
+    options: LinkViewsByObjectOptions | null = null,
+  ): this {
     const { meta = true, scopePrefix = null } = options || {};
 
     if (scopePrefix) {
@@ -637,7 +738,11 @@ export class CmvConfig {
    * @param {any} cValue The initial value for the coordination scope.
    * @returns {CmvConfigCoordinationScope} A coordination scope instance.
    */
-  setCoordinationValue(cType, cScope, cValue) {
+  setCoordinationValue(
+    cType: Extract<keyof CT, string>,
+    cScope: CoordinationScopeName,
+    cValue: CoordinationValue,
+  ): CmvConfigCoordinationScope {
     const scope = new CmvConfigCoordinationScope(cType, cScope, cValue);
     if (!this.config.coordinationSpace[scope.cType]) {
       this.config.coordinationSpace[scope.cType] = {};
@@ -650,7 +755,7 @@ export class CmvConfig {
    * Convert this instance to a JSON object that can be passed to a provider component.
    * @returns {object} The spec as a JSON object.
    */
-  toJSON() {
+  toJSON(): CmvConfigJson {
     const metaCoordinationScopes = Object.fromEntries(
       Object.entries(this.config.metaCoordination.coordinationScopes).map(([cScopeName, cScope]) => ([
         cScopeName,
@@ -663,7 +768,7 @@ export class CmvConfig {
         cScope.cValue,
       ])),
     );
-    const result = {
+    const result: CmvConfigJson = {
       key: this.config.key,
       coordinationSpace: Object.fromEntries(
         Object.entries(this.config.coordinationSpace).map(([cType, cScopes]) => ([
@@ -702,11 +807,11 @@ export class CmvConfig {
    * @returns {CmvConfig} A new config instance, with values set to match
    * the spec parameter.
    */
-  static fromJSON(spec) {
+  static fromJSON<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>>(spec: CmvConfigSpec): CmvConfig<CT> {
     const { key } = spec;
-    const vc = new CmvConfig(key);
+    const vc = new CmvConfig<CT>(key);
     Object.keys(spec.coordinationSpace || {}).forEach((cType) => {
-      const cObj = spec.coordinationSpace[cType];
+      const cObj = spec.coordinationSpace![cType];
       vc.config.coordinationSpace[cType] = {};
       Object.entries(cObj).forEach(([cScopeName, cScopeValue]) => {
         const scope = new CmvConfigCoordinationScope(cType, cScopeName);
@@ -725,17 +830,35 @@ export class CmvConfig {
       vc.config.metaCoordination.coordinationScopesBy[cScopeName] = scope;
     });
     Object.keys(spec.viewCoordination || {}).forEach((viewUid) => {
-      const viewObj = spec.viewCoordination[viewUid];
-      const newView = new CmvConfigView(viewObj.coordinationScopes, viewObj.coordinationScopesBy, viewObj.metaCoordinationScopes, viewObj.metaCoordinationScopesBy);
+      const viewObj = spec.viewCoordination![viewUid];
+      const newView = new CmvConfigView<CT>(
+        viewObj.coordinationScopes,
+        viewObj.coordinationScopesBy,
+        viewObj.metaCoordinationScopes,
+        viewObj.metaCoordinationScopesBy,
+      );
       vc.config.viewCoordination[viewUid] = newView;
     });
     return vc;
   }
 }
 
+export interface CoordinationSpaceAndScopesResult {
+  coordinationSpace: Record<CoordinationType, Record<CoordinationScopeName, CoordinationValue>>;
+  metaCoordinationScopes: Record<CoordinationScopeName, CoordinationScopesMap>;
+  metaCoordinationScopesBy: Record<CoordinationScopeName, CoordinationScopesByMap>;
+  coordinationScopes: CoordinationScopesMap | undefined;
+  coordinationScopesBy: CoordinationScopesByMap | undefined;
+  viewMetaCoordinationScopes: CoordinationScopeName[] | undefined;
+  viewMetaCoordinationScopesBy: CoordinationScopeName[] | undefined;
+}
+
 // For usage during auto-initialization.
-export function getCoordinationSpaceAndScopes(partialCoordinationValues, scopePrefix) {
-  const vc = new CmvConfig('__dummy__');
+export function getCoordinationSpaceAndScopes<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>>(
+  partialCoordinationValues: CoordinationInputOf<CT>,
+  scopePrefix: string,
+): CoordinationSpaceAndScopesResult {
+  const vc = new CmvConfig<CT>('__dummy__');
   vc.getNextScope = createPrefixedGetNextScopeNumeric(scopePrefix);
   const v1 = vc.addView('__dummy__');
   vc.linkViewsByObject([v1], partialCoordinationValues, { meta: true });

--- a/packages/config/src/CmvConfig.ts
+++ b/packages/config/src/CmvConfig.ts
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { z } from 'zod';
+import type { CoordinationSpace, CoordinationScopesMapping, CoordinationScopesByMapping } from '@use-coordination/types';
 import { META_COORDINATION_SCOPES, META_COORDINATION_SCOPES_BY } from '@use-coordination/constants-internal';
 import { getNextScope, createPrefixedGetNextScopeNumeric } from '@use-coordination/utils';
 
@@ -8,22 +9,16 @@ type CoordinationType = string;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CoordinationValue = any;
 
-type CoordinationScopesMap = Record<CoordinationType, CoordinationScopeName | CoordinationScopeName[]>;
-type CoordinationScopesByMap = Record<
-  CoordinationType,
-  Record<CoordinationType, Record<CoordinationScopeName, CoordinationScopeName | CoordinationScopeName[]>>
->;
-
 interface ViewJson {
-  coordinationScopes?: CoordinationScopesMap;
-  coordinationScopesBy?: CoordinationScopesByMap;
+  coordinationScopes?: CoordinationScopesMapping<CoordinationSpace>;
+  coordinationScopesBy?: CoordinationScopesByMapping<CoordinationSpace>;
   metaCoordinationScopes?: CoordinationScopeName[];
   metaCoordinationScopesBy?: CoordinationScopeName[];
 }
 
 interface MetaCoordinationJson {
-  coordinationScopes?: Record<CoordinationScopeName, CoordinationScopesMap>;
-  coordinationScopesBy?: Record<CoordinationScopeName, CoordinationScopesByMap>;
+  coordinationScopes?: Record<CoordinationScopeName, CoordinationScopesMapping<CoordinationSpace>>;
+  coordinationScopesBy?: Record<CoordinationScopeName, CoordinationScopesByMapping<CoordinationSpace>>;
 }
 
 export interface CmvConfigJson {
@@ -81,9 +76,9 @@ interface LinkViewsByObjectOptions {
 
 function useCoordinationByObjectHelper(
   scopes: ProcessedLevel,
-  coordinationScopes: CoordinationScopesMap,
-  coordinationScopesBy: CoordinationScopesByMap,
-): [CoordinationScopesMap, CoordinationScopesByMap] {
+  coordinationScopes: CoordinationScopesMapping<CoordinationSpace>,
+  coordinationScopesBy: CoordinationScopesByMapping<CoordinationSpace>,
+): [CoordinationScopesMapping<CoordinationSpace>, CoordinationScopesByMapping<CoordinationSpace>] {
   // Set this.coordinationScopes and this.coordinationScopesBy by recursion on `scopes`.
   /*
     // Destructured, `scopes` might look like:
@@ -238,8 +233,8 @@ export class CmvConfigView<CT extends Record<string, z.ZodTypeAny> = Record<stri
    * names to coordination scope names, for multi-level coordination.
    */
   constructor(
-    coordinationScopes: CoordinationScopesMap | undefined,
-    coordinationScopesBy: CoordinationScopesByMap | undefined,
+    coordinationScopes: CoordinationScopesMapping<CoordinationSpace> | undefined,
+    coordinationScopesBy: CoordinationScopesByMapping<CoordinationSpace> | undefined,
     metaCoordinationScopes?: CoordinationScopeName[],
     metaCoordinationScopesBy?: CoordinationScopeName[],
   ) {
@@ -851,10 +846,10 @@ export class CmvConfig<CT extends Record<string, z.ZodTypeAny> = Record<string, 
 
 export interface CoordinationSpaceAndScopesResult {
   coordinationSpace: Record<CoordinationType, Record<CoordinationScopeName, CoordinationValue>>;
-  metaCoordinationScopes: Record<CoordinationScopeName, CoordinationScopesMap>;
-  metaCoordinationScopesBy: Record<CoordinationScopeName, CoordinationScopesByMap>;
-  coordinationScopes: CoordinationScopesMap | undefined;
-  coordinationScopesBy: CoordinationScopesByMap | undefined;
+  metaCoordinationScopes: Record<CoordinationScopeName, CoordinationScopesMapping<CoordinationSpace>>;
+  metaCoordinationScopesBy: Record<CoordinationScopeName, CoordinationScopesByMapping<CoordinationSpace>>;
+  coordinationScopes: CoordinationScopesMapping<CoordinationSpace> | undefined;
+  coordinationScopesBy: CoordinationScopesByMapping<CoordinationSpace> | undefined;
   viewMetaCoordinationScopes: CoordinationScopeName[] | undefined;
   viewMetaCoordinationScopesBy: CoordinationScopeName[] | undefined;
 }

--- a/packages/config/src/CmvConfig.ts
+++ b/packages/config/src/CmvConfig.ts
@@ -312,11 +312,11 @@ export class CmvConfigView<CT extends Record<string, z.ZodTypeAny> = Record<stri
 }
 
 // would import as CL for convenience
-class CoordinationLevel {
-  value: CoordinationInput | CoordinationInput[];
+class CoordinationLevel<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>> {
+  value: CoordinationInputOf<CT> | CoordinationInputOf<CT>[];
   cachedValue: ProcessedLevelValue | null;
 
-  constructor(value: CoordinationInput | CoordinationInput[]) {
+  constructor(value: CoordinationInputOf<CT> | CoordinationInputOf<CT>[]) {
     this.value = value;
     this.cachedValue = null;
   }
@@ -334,8 +334,8 @@ class CoordinationLevel {
   }
 }
 
-export function CL(value: CoordinationInput | CoordinationInput[]): CoordinationLevel {
-  return new CoordinationLevel(value);
+export function CL<CT extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>>(value: CoordinationInputOf<CT> | CoordinationInputOf<CT>[]): CoordinationLevel<CT> {
+  return new CoordinationLevel<CT>(value);
 }
 
 /**

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -1,2 +1,1 @@
 export { CmvConfig, CL as CoordinationLevel, getCoordinationSpaceAndScopes } from './CmvConfig.js';
-

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "test": "pnpm exec vitest --run"
   },
   "dependencies": {
+    "@use-coordination/types": "workspace:*",
     "@use-coordination/constants-internal": "workspace:*",
     "@use-coordination/schemas": "workspace:*",
     "@use-coordination/utils": "workspace:*",

--- a/packages/core/src/generic-types.ts
+++ b/packages/core/src/generic-types.ts
@@ -1,62 +1,22 @@
-type CoordinationSpace = {
-  [coordinationScopeName: string]: {
-    [coordinationScope: string]: unknown;
-  };
-};
+export type {
+  CoordinationSpace,
+  CoordinationScopesMapping,
+  CoordinationScopesByMapping,
+  MetaCoordinationScopes,
+  MetaCoordinationScopesBy,
+  ViewCoordination,
+  Config,
+} from '@use-coordination/types';
 
-type CoordinationScopesMapping<T extends CoordinationSpace> = {
-  [K in keyof T]?: keyof T[K] | (keyof T[K])[];
-};
-
-type CoordinationScopesByMapping<T extends CoordinationSpace> = {
-  [K1 in keyof T]?: {
-    [K2 in keyof T]?: {
-      [K3 in keyof T[K1]]?: keyof T[K2] | (keyof T[K2])[];
-    };
-  };
-};
-
-// Each meta-scope value maps coordination types to scope names within those types.
-type MetaCoordinationScopes<T extends CoordinationSpace> = {
-  [metaScopeName: string]: CoordinationScopesMapping<T>;
-};
-
-// Each meta-by-scope value maps coordination types to scopes-by mappings.
-type MetaCoordinationScopesBy<T extends CoordinationSpace> = {
-  [metaScopeName: string]: CoordinationScopesByMapping<T>;
-};
-
-type ViewCoordination<
-  T extends CoordinationSpace,
-  MetaScopes extends MetaCoordinationScopes<T>,
-  MetaScopesBy extends MetaCoordinationScopesBy<T>,
-> = {
-  [viewId: string]: {
-    coordinationScopes?: CoordinationScopesMapping<T>;
-    coordinationScopesBy?: CoordinationScopesByMapping<T>;
-    metaCoordinationScopes?: keyof MetaScopes & string | (keyof MetaScopes & string)[];
-    metaCoordinationScopesBy?: keyof MetaScopesBy & string | (keyof MetaScopesBy & string)[];
-  };
-};
-
-type Config<
-  CoordinationSpaceT extends CoordinationSpace,
-  MetaCoordinationScopesT extends MetaCoordinationScopes<CoordinationSpaceT>,
-  MetaCoordinationScopesByT extends MetaCoordinationScopesBy<CoordinationSpaceT>,
-  ViewCoordinationT extends ViewCoordination<
-    CoordinationSpaceT,
-    MetaCoordinationScopesT,
-    MetaCoordinationScopesByT
-  >,
-> = {
-  key?: string | number;
-  coordinationSpace?: CoordinationSpaceT;
-  metaCoordination?: {
-    coordinationScopes?: MetaCoordinationScopesT;
-    coordinationScopesBy?: MetaCoordinationScopesByT;
-  };
-  viewCoordination?: ViewCoordinationT;
-};
+import type {
+  CoordinationSpace,
+  CoordinationScopesMapping,
+  CoordinationScopesByMapping,
+  MetaCoordinationScopes,
+  MetaCoordinationScopesBy,
+  ViewCoordination,
+  Config,
+} from '@use-coordination/types';
 
 export function defineSpec<
   CoordinationSpaceT extends CoordinationSpace,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@use-coordination/config",
+  "name": "@use-coordination/types",
   "version": "1.0.1",
   "author": "Mark Keller",
   "license": "MIT",
@@ -24,13 +24,7 @@
     "bundle": "pnpm exec vite build -c ../../scripts/vite.config.js",
     "test": "pnpm exec vitest --run"
   },
-  "dependencies": {
-    "@use-coordination/types": "workspace:*",
-    "@use-coordination/constants-internal": "workspace:*",
-    "@use-coordination/utils": "workspace:*"
-  },
   "devDependencies": {
-    "vitest": "^1.6.1",
-    "zod": "^4.3.0"
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,59 @@
+export type CoordinationSpace = {
+  [coordinationScopeName: string]: {
+    [coordinationScope: string]: unknown;
+  };
+};
+
+export type CoordinationScopesMapping<T extends CoordinationSpace> = {
+  [K in keyof T]?: keyof T[K] | (keyof T[K])[];
+};
+
+export type CoordinationScopesByMapping<T extends CoordinationSpace> = {
+  [K1 in keyof T]?: {
+    [K2 in keyof T]?: {
+      [K3 in keyof T[K1]]?: keyof T[K2] | (keyof T[K2])[];
+    };
+  };
+};
+
+// Each meta-scope value maps coordination types to scope names within those types.
+export type MetaCoordinationScopes<T extends CoordinationSpace> = {
+  [metaScopeName: string]: CoordinationScopesMapping<T>;
+};
+
+// Each meta-by-scope value maps coordination types to scopes-by mappings.
+export type MetaCoordinationScopesBy<T extends CoordinationSpace> = {
+  [metaScopeName: string]: CoordinationScopesByMapping<T>;
+};
+
+export type ViewCoordination<
+  T extends CoordinationSpace,
+  MetaScopes extends MetaCoordinationScopes<T>,
+  MetaScopesBy extends MetaCoordinationScopesBy<T>,
+> = {
+  [viewId: string]: {
+    coordinationScopes?: CoordinationScopesMapping<T>;
+    coordinationScopesBy?: CoordinationScopesByMapping<T>;
+    metaCoordinationScopes?: keyof MetaScopes & string | (keyof MetaScopes & string)[];
+    metaCoordinationScopesBy?: keyof MetaScopesBy & string | (keyof MetaScopesBy & string)[];
+  };
+};
+
+export type Config<
+  CoordinationSpaceT extends CoordinationSpace,
+  MetaCoordinationScopesT extends MetaCoordinationScopes<CoordinationSpaceT>,
+  MetaCoordinationScopesByT extends MetaCoordinationScopesBy<CoordinationSpaceT>,
+  ViewCoordinationT extends ViewCoordination<
+    CoordinationSpaceT,
+    MetaCoordinationScopesT,
+    MetaCoordinationScopesByT
+  >,
+> = {
+  key?: string | number;
+  coordinationSpace?: CoordinationSpaceT;
+  metaCoordination?: {
+    coordinationScopes?: MetaCoordinationScopesT;
+    coordinationScopesBy?: MetaCoordinationScopesByT;
+  };
+  viewCoordination?: ViewCoordinationT;
+};

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist-tsc",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       '@use-coordination/constants-internal':
         specifier: workspace:*
         version: link:../constants-internal
+      '@use-coordination/types':
+        specifier: workspace:*
+        version: link:../types
       '@use-coordination/utils':
         specifier: workspace:*
         version: link:../utils
@@ -386,6 +389,9 @@ importers:
       '@use-coordination/schemas':
         specifier: workspace:*
         version: link:../schemas
+      '@use-coordination/types':
+        specifier: workspace:*
+        version: link:../types
       '@use-coordination/utils':
         specifier: workspace:*
         version: link:../utils
@@ -618,6 +624,12 @@ importers:
       vite:
         specifier: ^5.4.0
         version: 5.4.21(@types/node@18.0.0)(sass@1.62.1)(terser@5.17.6)
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@18.0.0)(@vitest/ui@1.6.1)(jsdom@25.0.1)(sass@1.62.1)(terser@5.17.6)
+
+  packages/types:
+    devDependencies:
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@18.0.0)(@vitest/ui@1.6.1)(jsdom@25.0.1)(sass@1.62.1)(terser@5.17.6)
@@ -2504,9 +2516,6 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.14':
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -4151,10 +4160,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.2.0:
-    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
-    engines: {node: '>=0.4.0'}
-
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -5603,10 +5608,6 @@ packages:
     resolution: {integrity: sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==}
     engines: {node: '>= 4.2.1'}
     hasBin: true
-
-  diff-sequences@29.4.3:
-    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -9728,9 +9729,6 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  std-env@3.4.3:
-    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
 
   stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
@@ -14978,12 +14976,12 @@ snapshots:
   '@jridgewell/gen-mapping@0.1.1':
     dependencies:
       '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/gen-mapping@0.3.1':
     dependencies:
       '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.18
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -14994,7 +14992,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.18
 
   '@jridgewell/remapping@2.3.5':
@@ -15015,14 +15013,12 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.14': {}
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.13':
     dependencies:
       '@jridgewell/resolve-uri': 3.0.7
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.18':
     dependencies:
@@ -15032,7 +15028,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsdevtools/ono@7.1.3': {}
 
@@ -16967,11 +16963,11 @@ snapshots:
   '@types/eslint-scope@3.7.3':
     dependencies:
       '@types/eslint': 8.4.3
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.4.3':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.11
 
   '@types/estree@0.0.51': {}
@@ -17568,11 +17564,9 @@ snapshots:
     dependencies:
       acorn: 8.11.2
 
-  acorn-walk@8.2.0: {}
-
   acorn-walk@8.3.5:
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.16.0
 
   acorn@6.4.2: {}
 
@@ -17807,7 +17801,7 @@ snapshots:
       caniuse-lite: 1.0.30001489
       fraction.js: 4.2.0
       normalize-range: 0.1.2
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       postcss: 8.4.14
       postcss-value-parser: 4.2.0
 
@@ -17817,7 +17811,7 @@ snapshots:
       caniuse-lite: 1.0.30001489
       fraction.js: 4.2.0
       normalize-range: 0.1.2
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       postcss: 8.4.23
       postcss-value-parser: 4.2.0
 
@@ -18212,7 +18206,7 @@ snapshots:
       check-error: 1.0.3
       deep-eql: 4.1.3
       get-func-name: 2.0.2
-      loupe: 2.3.6
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.1.0
 
@@ -19317,8 +19311,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  diff-sequences@29.4.3: {}
-
   diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
@@ -19923,7 +19915,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -21175,7 +21167,7 @@ snapshots:
   jest-diff@29.5.0:
     dependencies:
       chalk: 4.1.2
-      diff-sequences: 29.4.3
+      diff-sequences: 29.6.3
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
 
@@ -24016,7 +24008,7 @@ snapshots:
   rtlcss@3.5.0:
     dependencies:
       find-up: 5.0.0
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       postcss: 8.4.23
       strip-json-comments: 3.1.1
 
@@ -24417,8 +24409,6 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  std-env@3.4.3: {}
-
   stop-iteration-iterator@1.0.0:
     dependencies:
       internal-slot: 1.0.5
@@ -24625,7 +24615,7 @@ snapshots:
       css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       stable: 0.1.8
 
   symbol-tree@3.2.4: {}
@@ -24962,7 +24952,7 @@ snapshots:
     dependencies:
       browserslist: 4.21.5
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -25451,7 +25441,7 @@ snapshots:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       vite: 5.4.21(@types/node@18.0.0)(sass@1.62.1)(terser@5.17.6)
     transitivePeerDependencies:
       - '@types/node'
@@ -25532,7 +25522,7 @@ snapshots:
       local-pkg: 0.5.1
       magic-string: 0.30.21
       pathe: 1.1.2
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       std-env: 3.10.0
       strip-literal: 2.1.1
       tinybench: 2.9.0
@@ -25608,7 +25598,7 @@ snapshots:
   webpack-bundle-analyzer@4.5.0:
     dependencies:
       acorn: 8.11.2
-      acorn-walk: 8.2.0
+      acorn-walk: 8.3.5
       chalk: 4.1.2
       commander: 7.2.0
       gzip-size: 6.0.0
@@ -25710,7 +25700,7 @@ snapshots:
       chalk: 4.1.2
       consola: 2.15.3
       pretty-time: 1.1.0
-      std-env: 3.4.3
+      std-env: 3.10.0
       webpack: 5.73.0
 
   websocket-driver@0.7.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@18.0.0)(@vitest/ui@1.6.1)(jsdom@25.0.1)(sass@1.62.1)(terser@5.17.6)
+      zod:
+        specifier: ^4.3.0
+        version: 4.3.6
 
   packages/constants-internal:
     devDependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "packages/types" },
     { "path": "packages/config" },
     { "path": "packages/constants-internal" },
     { "path": "packages/utils" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,9 @@
   },
   "references": [
     { "path": "packages/types" },
-    { "path": "packages/config" },
     { "path": "packages/constants-internal" },
     { "path": "packages/utils" },
+    { "path": "packages/config" },
     { "path": "packages/schemas" },
     { "path": "packages/trrack-helpers" },
     { "path": "packages/graphviz-renderer" },


### PR DESCRIPTION
Fixes #23 

TODO: implement #56 in order to share types between `core` and `config` sub-packages